### PR TITLE
selected color scheme persists - still needs some more testing

### DIFF
--- a/src/utils/togglePreferColorScheme.js
+++ b/src/utils/togglePreferColorScheme.js
@@ -8,15 +8,18 @@ export default (() => {
       window.matchMedia("(prefers-color-scheme: dark)").matches)
   ) {
     document.documentElement.classList.add("dark");
+
   } else {
     document.documentElement.classList.remove("dark");
   }
   // Whenever the user explicitly chooses light mode
-  localStorage.theme = "light";
+  // localStorage.theme = "light";
 
   // Whenever the user explicitly chooses dark mode
-  localStorage.theme = "dark";
+  // localStorage.theme = "dark";
 
   // Whenever the user explicitly chooses to respect the OS preference
-  localStorage.removeItem("theme");
+  // localStorage.removeItem("theme");
+
+  console.log("prefered color scheme=",window.matchMedia("(prefers-color-scheme: dark)").matches);
 })();


### PR DESCRIPTION
Browser should persist theme selected by user on refresh. If user chooses "light" mode browser should persist "light" mode on refresh until manually changed.

Notes:
There is no consistency. If user refreshes browser theme will persist for one refresh but then theme is removed from local storage. In subsequent refreshes there is no theme in local storage to be read. So browser sets default theme.

Reconfigured logic in togglePrefereColorScheme 